### PR TITLE
compatibility with stricter environments

### DIFF
--- a/HELM Chart/Chart.yaml
+++ b/HELM Chart/Chart.yaml
@@ -9,7 +9,7 @@ description: SMConnector by GentlemenGroup, powered by freedom manufaktur.
 type: application
 
 # Version of this Chart - https://helm.sh/docs/topics/charts/#charts-and-versioning
-version: 2.1.3
+version: 2.1.4
 
 # The version of the app that this contains (optional). - https://helm.sh/docs/topics/charts/#the-appversion-field
 appVersion: "2.1.3" # or latest

--- a/HELM Chart/templates/deployment.yaml
+++ b/HELM Chart/templates/deployment.yaml
@@ -67,6 +67,9 @@ spec:
                 configMapKeyRef:
                   name: {{ include "sm-connector.fullname" . }}
                   key: Api.EnableSwagger
+            {{- if .Values.extraEnvVars }}
+            {{- toYaml .Values.extraEnvVars | nindent 12 }}
+            {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           {{- with .Values.volumeMounts }}

--- a/HELM Chart/templates/persistentvolume.yaml
+++ b/HELM Chart/templates/persistentvolume.yaml
@@ -1,5 +1,6 @@
 ﻿# Create a persistent volume (PV) that points to the hosting system (kubernetes host)
 # https://kubernetes.io/docs/concepts/storage/persistent-volumes/#persistent-volumes
+{{- if .Values.volume.volumeEnabled -}}
 apiVersion: v1
 kind: PersistentVolume
 metadata:
@@ -14,3 +15,4 @@ spec:
     - ReadWriteOnce
   hostPath:
     path: {{ .Values.volume.hostPath }}
+{{- end -}}

--- a/HELM Chart/templates/persistentvolumeclaim.yaml
+++ b/HELM Chart/templates/persistentvolumeclaim.yaml
@@ -7,7 +7,9 @@ metadata:
   labels:
     {{- include "sm-connector.labels" . | nindent 4 }}
 spec:
+  {{- if .Values.volume.storageClassName }}
   storageClassName: {{ .Values.volume.storageClassName }}
+  {{- end }}
   accessModes:
     - ReadWriteOnce # the volume can be mounted as read-write by a single node. ReadWriteOnce access mode still can allow multiple pods to access the volume when the pods are running on the same node. For single pod access, please see ReadWriteOncePod.
   resources:

--- a/HELM Chart/values.yaml
+++ b/HELM Chart/values.yaml
@@ -107,6 +107,7 @@ volumes:
     claimName: sm-connector
 
 volume:
+  volumeEnabled: true
   storageClassName: manual
   capacity: 1Gi
   # Windows Docker Desktop Kubernetes (1.30.2):

--- a/HELM Chart/values.yaml
+++ b/HELM Chart/values.yaml
@@ -124,3 +124,7 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+## @param extraEnvVars Array to add extra environment variables
+##
+extraEnvVars: []


### PR DESCRIPTION
- add option to disable volume creation
- add option to specify extra environment variables
- only specify PVC storageClassName if non-empty

Changes are backward-compatible, defaults are staying the same.